### PR TITLE
Make sure only a non-deleted engine is returned

### DIFF
--- a/railib/api.py
+++ b/railib/api.py
@@ -148,7 +148,7 @@ def delete_user(ctx: Context, user: str) -> dict:
 
 
 def get_engine(ctx: Context, engine: str) -> dict:
-    return _get_resource(ctx, PATH_ENGINE, name=engine, key="computes")
+    return _get_resource(ctx, PATH_ENGINE, name=engine, deleted_on="", key="computes")
 
 
 def get_database(ctx: Context, database: str) -> dict:


### PR DESCRIPTION
If https://github.com/RelationalAI/relationalai-infra/pull/1832 is merged, then multiple compute might have the same name. I think railib's `get_engine` should only return a non-deleted one (if one exists).

This PR should only be merged after https://github.com/RelationalAI/relationalai-infra/pull/1832 is in.