### PR TITLE
Delete database by name

### DIFF
--- a/examples/delete_database.py
+++ b/examples/delete_database.py
@@ -27,9 +27,9 @@ def run(database: str):
 
 if __name__ == "__main__":
     p = ArgumentParser()
-    p.add_argument("id", type=str, nargs=1, help="database name")
+    p.add_argument("name", type=str, nargs=1, help="database name")
     args = p.parse_args()
     try:
-        run(args.id[0])
+        run(args.name)
     except HTTPError as e:
         show.http_error(e)

--- a/examples/delete_database.py
+++ b/examples/delete_database.py
@@ -27,7 +27,7 @@ def run(database: str):
 
 if __name__ == "__main__":
     p = ArgumentParser()
-    p.add_argument("id", type=str, nargs=1, help="database id")
+    p.add_argument("id", type=str, nargs=1, help="database name")
     args = p.parse_args()
     try:
         run(args.id[0])

--- a/railib/api.py
+++ b/railib/api.py
@@ -138,8 +138,9 @@ def delete_engine(ctx: Context, engine: str) -> dict:
 
 
 def delete_database(ctx: Context, database: str) -> dict:
-    url = _mkurl(ctx, f"{PATH_DATABASE}/{database}")
-    rsp = rest.delete(ctx, url, None)
+    data = {"name": database}
+    url = _mkurl(ctx, PATH_DATABASE)
+    rsp = rest.delete(ctx, url, data)
     return json.loads(rsp)
 
 

--- a/railib/api.py
+++ b/railib/api.py
@@ -148,7 +148,7 @@ def delete_user(ctx: Context, user: str) -> dict:
 
 
 def get_engine(ctx: Context, engine: str) -> dict:
-    return _get_resource(ctx, PATH_ENGINE, name=engine, key="computes")
+    return _get_resource(ctx, PATH_ENGINE, name=engine, deleted_on="", key="computes")
 
 
 def get_database(ctx: Context, database: str) -> dict:


### PR DESCRIPTION
After https://github.com/RelationalAI/relationalai-infra/pull/1837 is in, the frontend will support deleting databases by name (similar to `/compute`). This PR exposes that functionality to the SDK.