### PR TITLE
No need for terminal check in delete database

### DIFF
--- a/examples/delete_database.py
+++ b/examples/delete_database.py
@@ -14,25 +14,14 @@
 
 from argparse import ArgumentParser
 import json
-import time
 from urllib.request import HTTPError
 from railib import api, config, show
-
-
-# Answers if the given state is a terminal state.
-def is_term_state(state: str) -> bool:
-    return state == "DELETED" or ("FAILED" in state)
 
 
 def run(database: str):
     cfg = config.read()
     ctx = api.Context(**cfg)
     rsp = api.delete_database(ctx, database)
-    while True:  # wait for request to reach terminal state
-        time.sleep(3)
-        rsp = api.get_database(ctx, database)
-        if not rsp or is_term_state(rsp["state"]):
-            break
     print(json.dumps(rsp, indent=2))
 
 


### PR DESCRIPTION
I think it's not needed because DELETE /database always returns a terminal state