### PR TITLE
Refactor async transaction slightly

### DIFF
--- a/examples/get_transaction_results.py
+++ b/examples/get_transaction_results.py
@@ -1,0 +1,38 @@
+# Copyright 2021-2022 RelationalAI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+"""Fetch results for the given transaction."""
+
+from argparse import ArgumentParser
+from urllib.request import HTTPError
+from railib import api, config, show
+
+
+def run(id: str, profile: str):
+    cfg = config.read(profile=profile)
+    ctx = api.Context(**cfg)
+    rsp = api.get_transaction_results(ctx, id)
+    show.results(rsp, "multipart")
+
+
+if __name__ == "__main__":
+    p = ArgumentParser()
+    p.add_argument("-p", "--profile", type=str,
+                   help="profile name", default="default")
+    p.add_argument("id", type=str, help="transaction id")
+    args = p.parse_args()
+    try:
+        run(args.id, args.profile)
+    except HTTPError as e:
+        show.http_error(e)

--- a/examples/run_query_async.py
+++ b/examples/run_query_async.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-import json
 from argparse import ArgumentParser
 from urllib.request import HTTPError
 from railib import api, config, show
@@ -21,7 +20,7 @@ def run(database: str, engine: str, command: str, readonly: bool, profile: str):
     cfg = config.read(profile=profile)
     ctx = api.Context(**cfg)
     rsp = api.query_async(ctx, database, engine, command, readonly=readonly)
-    show.results(rsp, "multipart")
+    show.results(rsp, "multipart" if isinstance(rsp, list) else "wire")
 
 
 if __name__ == "__main__":

--- a/railib/api.py
+++ b/railib/api.py
@@ -17,7 +17,7 @@
 import io
 import json
 from enum import Enum, unique
-from typing import List
+from typing import List, Union
 from . import rest
 
 PATH_ENGINE = "/compute"
@@ -166,18 +166,30 @@ def _list_collection(ctx, path: str, key=None, **kwargs):
     return rsp[key] if key else rsp
 
 
-# Finds and returns the multipart form-data boundary
-# Boundary is something like,
-# "Content-Type: multipart/form-data; boundary=d6d47cadd395db7f6648a2ffb65751eb"
-def _get_multipart_data_boundary(content_type):
-    if (";" in content_type) and ("=" in content_type):
-        strings = content_type.split(";")
-        strings = strings[len(strings) - 1].split("=")
-        boundary = strings[len(strings) - 1].encode("utf-8")
-        # one part is separated from the other like, --boundary=bla
-        return b''.join((b'--', boundary))
+# Parses "multipart/form-data" responses. It returns the parts in a list.
+def _parse_multipart(content_type: str, content: bytes) -> list:
+    result = []
+    boundary = _extract_multipart_boundary(content_type)
+    parts = content.split(b'\r\n' + boundary)
+    for i, part in enumerate(parts):
+        # fix the first part, it may contain the boundary
+        if i == 0:
+            part = part.split(boundary)[-1]
+        # skip the part which contains the following
+        if b'--\r\n' in part:
+            continue
+        # append the part
+        result.append(part)
+    return result
 
-    return None
+
+# Finds and returns the multipart form-data boundary.
+# Example:
+#   "Content-Type: multipart/form-data; boundary=d6d47cadd395db7f6648a2ffb65751eb"
+def _extract_multipart_boundary(content_type: str) -> bytes:
+    if "boundary=" not in content_type:
+        raise Exception("no multipart boundary")
+    return b'--' + content_type.split("boundary=")[-1].encode("utf-8")
 
 
 def create_engine(ctx: Context, engine: str, size: EngineSize = EngineSize.XS):
@@ -390,7 +402,8 @@ class TransactionAsync(object):
         result = {
             "dbname": self.database,
             "nowait_durable": self.nowait_durable,
-            "readonly": self.readonly
+            "readonly": self.readonly,
+            # "sync_mode": "async"
         }
         if self.engine is not None:
             result["engine_name"] = self.engine
@@ -398,32 +411,19 @@ class TransactionAsync(object):
         result["inputs"] = inputs
         return result
 
-    def run(self, ctx: Context) -> []:
+    def run(self, ctx: Context) -> Union[dict, list]:
         data = self.data
         url = _mkurl(ctx, PATH_TRANSACTIONS)
         rsp = rest.post(ctx, url, data)
         content_type = rsp.headers.get('content-type', None)
         content = rsp.read()
-        if ("form-data" in content_type) and (b'\r\n\r\n' in content):
-            boundary = _get_multipart_data_boundary(content_type)
-            result = []
-            if boundary:
-                parts = content.split(b''.join((b'\r\n', boundary)))
-                for x in range(0, len(parts) - 1):
-                    part = parts[x]
-                    # fix the first part, it may contain the boundary
-                    if x == 0:
-                        first_part_parts = part.split(boundary)
-                        part = first_part_parts[len(first_part_parts) - 1]
-                    # skip the part which contains the following
-                    if b'--\r\n' in part:
-                        continue
-                    # append the part
-                    result.append(part)
-
-                return result
-
-        raise Exception("Not a valid multipart response")
+        # async mode
+        if content_type.lower() == "application/json":
+            return json.loads(content)
+        # sync mode
+        if "multipart/form-data" in content_type.lower():
+            return _parse_multipart(content_type, content)
+        raise Exception("invalid response type")
 
 
 def _delete_model_action(name: str) -> dict:
@@ -643,7 +643,7 @@ def query(ctx: Context, database: str, engine: str, command: str,
 
 
 def query_async(ctx: Context, database: str, engine: str, command: str,
-                readonly: bool = True, inputs: dict = None) -> list:
+                readonly: bool = True, inputs: dict = None) -> Union[dict, list]:
     tx = TransactionAsync(database, engine, command, readonly=readonly, inputs=inputs)
     return tx.run(ctx)
 

--- a/railib/api.py
+++ b/railib/api.py
@@ -118,6 +118,7 @@ __all__ = [
     "get_model",
     "get_oauth_client",
     "get_transaction",
+    "get_transaction_results",
     "get_user",
     "list_databases",
     "list_edbs",
@@ -285,6 +286,15 @@ def get_oauth_client(ctx: Context, id: str) -> dict:
 
 def get_transaction(ctx: Context, id: str) -> dict:
     return _get_resource(ctx, f"{PATH_TRANSACTIONS}/{id}", key="transaction")
+
+
+def get_transaction_results(ctx: Context, id: str) -> list:
+    url = _mkurl(ctx, f"{PATH_TRANSACTIONS}/{id}/results")
+    rsp = rest.get(ctx, url)
+    content_type = rsp.headers.get('content-type', "")
+    if "multipart/form-data" not in content_type:
+        raise Exception("invalid response type")
+    return _parse_multipart(content_type, rsp.read())
 
 
 def get_user(ctx: Context, userid: str) -> dict:

--- a/railib/show.py
+++ b/railib/show.py
@@ -16,12 +16,13 @@
 
 import json
 import sys
+from typing import Union
 from urllib.request import HTTPError
 import pyarrow as pa
 
 __all__ = [
-    "http_error"
-    "problems"
+    "http_error",
+    "problems",
     "results"
 ]
 
@@ -75,11 +76,11 @@ def _show_rel(rsp: dict) -> None:
         print(rsp["status"])
 
 
-def _show_multipart(rsp):
+def _show_multipart(parts: list):
     result = []
     content_type_json = b'application/json'
     content_type_arrow_stream = b'application/vnd.apache.arrow.stream'
-    for part in rsp:
+    for part in parts:
         # split the part
         # part body and headers are separated with CRLFCRLF
         strings = part.split(b'\r\n\r\n')
@@ -121,7 +122,7 @@ def problems(rsp: dict) -> None:
 
 
 # Print the results contained in the given response dict.
-def results(rsp: dict, format="physical") -> None:
+def results(rsp: Union[dict, list], format="physical") -> None:
     if rsp is None:
         return
     if format == "wire":


### PR DESCRIPTION
- Handle both async (json) & sync (multipart) modes
- Simplify mutlipart parsing. Though it can be improved further.
- Make multipart parsing re-usable. It'll be used by the results endpoint.
- Fix exports in show.py
- Fix type annotations