### PR TITLE
add config option for overriding auth0 audience

### DIFF
--- a/railib/api.py
+++ b/railib/api.py
@@ -136,12 +136,12 @@ __all__ = [
 # Context contains the state required to make rAI API calls.
 class Context(rest.Context):
     def __init__(self, host: str = None, port: str = None, scheme: str = None,
-                 region: str = None, credentials=None, auth0_audience: str = None):
+                 region: str = None, credentials=None, audience: str = None):
         super().__init__(region=region, credentials=credentials)
         self.host = host
         self.port = port or "443"
         self.scheme = scheme or "https"
-        self.auth0_audience = auth0_audience
+        self.audience = audience
 
 
 # Construct a URL from the given context and path.

--- a/railib/api.py
+++ b/railib/api.py
@@ -136,11 +136,12 @@ __all__ = [
 # Context contains the state required to make rAI API calls.
 class Context(rest.Context):
     def __init__(self, host: str = None, port: str = None, scheme: str = None,
-                 region: str = None, credentials=None):
+                 region: str = None, credentials=None, auth0_audience: str = None):
         super().__init__(region=region, credentials=credentials)
         self.host = host
         self.port = port or "443"
         self.scheme = scheme or "https"
+        self.auth0_audience = auth0_audience
 
 
 # Construct a URL from the given context and path.

--- a/railib/config.py
+++ b/railib/config.py
@@ -84,7 +84,7 @@ def read(fname: str = "~/.rai/config", profile: str = "default"):
         raise Exception(f"can't find file: {path}")
     data = _read_config_profile(path, profile)
     creds = _read_credentials(data, path)
-    _keys = ["host", "port", "region", "scheme", "auth0_audience"]
+    _keys = ["host", "port", "region", "scheme", "audience"]
     result = {k: v for k, v in data.items() if k in _keys}
     result["credentials"] = creds
     return result

--- a/railib/config.py
+++ b/railib/config.py
@@ -84,7 +84,7 @@ def read(fname: str = "~/.rai/config", profile: str = "default"):
         raise Exception(f"can't find file: {path}")
     data = _read_config_profile(path, profile)
     creds = _read_credentials(data, path)
-    _keys = ["host", "port", "region", "scheme"]
+    _keys = ["host", "port", "region", "scheme", "auth0_audience"]
     result = {k: v for k, v in data.items() if k in _keys}
     result["credentials"] = creds
     return result

--- a/railib/rest.py
+++ b/railib/rest.py
@@ -131,7 +131,7 @@ def _request_access_token(ctx: Context, url: str) -> AccessToken:
     creds = ctx.credentials
     assert type(creds) == ClientCredentials
     # ensure the audience contains the protocol scheme
-    audience = f"https://{_get_host(url)}"
+    audience = ctx.auth0_audience or f"https://{_get_host(url)}"
     headers = {
         "Accept": "application/json",
         "Content-Type": "application/json",

--- a/railib/rest.py
+++ b/railib/rest.py
@@ -131,7 +131,7 @@ def _request_access_token(ctx: Context, url: str) -> AccessToken:
     creds = ctx.credentials
     assert type(creds) == ClientCredentials
     # ensure the audience contains the protocol scheme
-    audience = ctx.auth0_audience or f"https://{_get_host(url)}"
+    audience = ctx.audience or f"https://{_get_host(url)}"
     headers = {
         "Accept": "application/json",
         "Content-Type": "application/json",


### PR DESCRIPTION
I'm using a local txn service and a local rai engine.

Without this, I was getting:

```
$ python3 examples/run_query.py -p local vilterp-test-3 vilterp-test '2+3'
status: 403
{
  "error": "access_denied",
  "error_description": "Service not enabled within domain: https://127.0.0.1/"
}
```

With this `~/.rai/config`:

```
[local]
infra = AZURE
host = 127.0.0.1
port = 8082
scheme = http
region = us-east
client_id = ...
client_secret = ...
client_credentials_url = https://relationalai-ux.us.auth0.com/oauth/token
```

Now, I can spoof auth0 into thinking I'm not on localhost, but the actual site:

```diff
[local]
infra = AZURE
host = 127.0.0.1
port = 8082
scheme = http
region = us-east
client_id = ...
client_secret = ...
client_credentials_url = https://relationalai-ux.us.auth0.com/oauth/token
+ audience = https://azure-ux.relationalai.com
```

Not sure if there's a different way of doing this, or if it's something we want to have in the public SDK 🤔 