### PR TITLE
Add support for getting transaction metadata

### DIFF
--- a/examples/get_transaction_metadata.py
+++ b/examples/get_transaction_metadata.py
@@ -1,0 +1,39 @@
+# Copyright 2021-2022 RelationalAI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+"""Fetch metadata for the given transaction."""
+
+import json
+from argparse import ArgumentParser
+from urllib.request import HTTPError
+from railib import api, config, show
+
+
+def run(id: str, profile: str):
+    cfg = config.read(profile=profile)
+    ctx = api.Context(**cfg)
+    rsp = api.get_transaction_metadata(ctx, id)
+    print(json.dumps(rsp, indent=2))
+
+
+if __name__ == "__main__":
+    p = ArgumentParser()
+    p.add_argument("-p", "--profile", type=str,
+                   help="profile name", default="default")
+    p.add_argument("id", type=str, help="transaction id")
+    args = p.parse_args()
+    try:
+        run(args.id, args.profile)
+    except HTTPError as e:
+        show.http_error(e)

--- a/railib/api.py
+++ b/railib/api.py
@@ -118,6 +118,7 @@ __all__ = [
     "get_model",
     "get_oauth_client",
     "get_transaction",
+    "get_transaction_metadata",
     "get_transaction_results",
     "get_user",
     "list_databases",
@@ -286,6 +287,10 @@ def get_oauth_client(ctx: Context, id: str) -> dict:
 
 def get_transaction(ctx: Context, id: str) -> dict:
     return _get_resource(ctx, f"{PATH_TRANSACTIONS}/{id}", key="transaction")
+
+
+def get_transaction_metadata(ctx: Context, id: str) -> dict:
+    return _get_resource(ctx, f"{PATH_TRANSACTIONS}/{id}/metadata")
 
 
 def get_transaction_results(ctx: Context, id: str) -> list:


### PR DESCRIPTION
This is basically https://github.com/RelationalAI/rai-sdk-python/pull/68. I merged https://github.com/RelationalAI/rai-sdk-python/pull/67 before https://github.com/RelationalAI/rai-sdk-python/pull/68 (did not check the base branch) and it resulted in not having the metadata changes in main. 