### PR TITLE
Return the entire JSON response for get_transaction_metadata.py

### DIFF
--- a/railib/api.py
+++ b/railib/api.py
@@ -155,6 +155,9 @@ def _get_resource(ctx: Context, path: str, key=None, **kwargs) -> dict:
     rsp = json.loads(rsp.read())
     if key:
         rsp = rsp[key]
+    if rsp and isinstance(rsp, list):
+        assert len(rsp) == 1
+        return rsp[0]
     return rsp
 
 
@@ -287,8 +290,10 @@ def get_transaction(ctx: Context, id: str) -> dict:
 
 
 def get_transaction_metadata(ctx: Context, id: str) -> dict:
-    return _get_resource(ctx, f"{PATH_TRANSACTIONS}/{id}/metadata")
-
+    url = _mkurl(ctx, f"{PATH_TRANSACTIONS}/{id}/metadata")
+    rsp = rest.get(ctx, url)
+    rsp = json.loads(rsp.read())
+    return rsp
 
 def get_transaction_results(ctx: Context, id: str) -> list:
     url = _mkurl(ctx, f"{PATH_TRANSACTIONS}/{id}/results")

--- a/railib/api.py
+++ b/railib/api.py
@@ -162,7 +162,7 @@ def _get_resource(ctx: Context, path: str, key=None, **kwargs) -> dict:
 
 
 # Retrieve a generic collection of resources.
-def _list_collection(ctx, path: str, key=None, **kwargs):
+def _get_collection(ctx, path: str, key=None, **kwargs):
     rsp = rest.get(ctx, _mkurl(ctx, path), **kwargs)
     rsp = json.loads(rsp.read())
     return rsp[key] if key else rsp
@@ -290,10 +290,7 @@ def get_transaction(ctx: Context, id: str) -> dict:
 
 
 def get_transaction_metadata(ctx: Context, id: str) -> dict:
-    url = _mkurl(ctx, f"{PATH_TRANSACTIONS}/{id}/metadata")
-    rsp = rest.get(ctx, url)
-    rsp = json.loads(rsp.read())
-    return rsp
+    return _get_collection(ctx, f"{PATH_TRANSACTIONS}/{id}/metadata")
 
 def get_transaction_results(ctx: Context, id: str) -> list:
     url = _mkurl(ctx, f"{PATH_TRANSACTIONS}/{id}/results")
@@ -312,22 +309,22 @@ def list_engines(ctx: Context, state=None) -> list:
     kwargs = {}
     if state is not None:
         kwargs["state"] = state
-    return _list_collection(ctx, PATH_ENGINE, key="computes", **kwargs)
+    return _get_collection(ctx, PATH_ENGINE, key="computes", **kwargs)
 
 
 def list_databases(ctx: Context, state=None) -> list:
     kwargs = {}
     if state is not None:
         kwargs["state"] = state
-    return _list_collection(ctx, PATH_DATABASE, key="databases", **kwargs)
+    return _get_collection(ctx, PATH_DATABASE, key="databases", **kwargs)
 
 
 def list_users(ctx: Context) -> list:
-    return _list_collection(ctx, PATH_USER, key="users")
+    return _get_collection(ctx, PATH_USER, key="users")
 
 
 def list_oauth_clients(ctx: Context) -> list:
-    return _list_collection(ctx, PATH_OAUTH_CLIENT, key="clients")
+    return _get_collection(ctx, PATH_OAUTH_CLIENT, key="clients")
 
 
 def update_user(ctx: Context, userid: str, status: str = None, roles=None):

--- a/railib/api.py
+++ b/railib/api.py
@@ -155,9 +155,6 @@ def _get_resource(ctx: Context, path: str, key=None, **kwargs) -> dict:
     rsp = json.loads(rsp.read())
     if key:
         rsp = rsp[key]
-    if rsp and isinstance(rsp, list):
-        assert len(rsp) == 1
-        return rsp[0]
     return rsp
 
 

--- a/railib/api.py
+++ b/railib/api.py
@@ -292,6 +292,7 @@ def get_transaction(ctx: Context, id: str) -> dict:
 def get_transaction_metadata(ctx: Context, id: str) -> dict:
     return _get_collection(ctx, f"{PATH_TRANSACTIONS}/{id}/metadata")
 
+
 def get_transaction_results(ctx: Context, id: str) -> list:
     url = _mkurl(ctx, f"{PATH_TRANSACTIONS}/{id}/results")
     rsp = rest.get(ctx, url)


### PR DESCRIPTION
get_transaction_metadata returns a list, not a single item. For example, running `{:x, 2; :y, 3}` query produces a list of two items: 
```
[
  {
    "relationId": "/:output/:x/Int64",
    "types": [
      ":output",
      ":x",
      "Int64"
    ]
  },
  {
    "relationId": "/:output/:y/Int64",
    "types": [
      ":output",
      ":y",
      "Int64"
    ]
  }
]
```
However, the python SDK is failing because `get_transaction_metadata`  calls `_get_resource` function, which fails at the `assert len(rsp) == 1` condition. Fixing this by calling _get_collection instead of _get_resource. I also renamed _list_collection to _get_collection because I think it makes more sense.