### PR TITLE
Include problems in GET /transactions/{id}/results

### DIFF
--- a/examples/get_transaction_results.py
+++ b/examples/get_transaction_results.py
@@ -14,6 +14,7 @@
 
 """Fetch results for the given transaction."""
 
+import json
 from argparse import ArgumentParser
 from urllib.request import HTTPError
 from railib import api, config, show
@@ -23,7 +24,12 @@ def run(id: str, profile: str):
     cfg = config.read(profile=profile)
     ctx = api.Context(**cfg)
     rsp = api.get_transaction_results(ctx, id)
+    print("Results:")
     show.results(rsp, "multipart")
+
+    rsp = api.get_transaction_problems(ctx, id)
+    print("\nProblems:")
+    print(json.dumps(rsp, indent=2))
 
 
 if __name__ == "__main__":

--- a/railib/api.py
+++ b/railib/api.py
@@ -292,6 +292,8 @@ def get_transaction(ctx: Context, id: str) -> dict:
 def get_transaction_metadata(ctx: Context, id: str) -> dict:
     return _get_collection(ctx, f"{PATH_TRANSACTIONS}/{id}/metadata")
 
+def get_transaction_problems(ctx: Context, id: str) -> dict:
+    return _get_collection(ctx, f"{PATH_TRANSACTIONS}/{id}/problems")
 
 def get_transaction_results(ctx: Context, id: str) -> list:
     url = _mkurl(ctx, f"{PATH_TRANSACTIONS}/{id}/results")


### PR DESCRIPTION
Depends on https://github.com/RelationalAI/relationalai-infra/pull/2334. 
Including problems when fetching results. This will be deprecated when problems are included in relations and not an independent arrow file. 
I'm not sure if this is the best way to represent the output, but I'm open to ideas!