### PR TITLE
RAI-16267 Removed unnecessary dependencies, picked newer versions of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-grpcio==1.54.0
+grpcio==1.48.2
 grpcio-tools==1.47.0
-protobuf==3.20.2
-pyarrow==6.0.1
-requests==2.30.0
+protobuf==3.20.3
+pyarrow==10.0.1
 requests-toolbelt==1.0.0
-urllib3==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.48.2
+grpcio==1.54.0
 grpcio-tools==1.47.0
 protobuf==3.20.3
 pyarrow==10.0.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     ],
     description="The RelationalAI Software Development Kit for Python",
     install_requires=[
-        "ed25519==1.5",
         "pyarrow==10.0.1",
         "requests-toolbelt==1.0.0",
         "protobuf==3.20.3"],

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
     description="The RelationalAI Software Development Kit for Python",
     install_requires=[
         "ed25519==1.5",
-        "pyarrow==6.0.1",
+        "pyarrow==10.0.1",
         "requests-toolbelt==1.0.0",
-        "protobuf==3.20.2"],
+        "protobuf==3.20.3"],
     license="http://www.apache.org/licenses/LICENSE-2.0",
     long_description="Enables access to the RelationalAI REST APIs from Python",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Although the versions of the dependencies picked based on the availability of them in Anaconda Snowflake channel ensuing the versions availability in Anaconda Snowflake channel will likely become unnecessary since the Snowflake-friendly version of the SDK will likely be distributed as a separate package so all the existing dependencies versions won't matter in case of SF and vice versa.