### PR TITLE
create .rai if necessary

### DIFF
--- a/railib/rest.py
+++ b/railib/rest.py
@@ -16,7 +16,7 @@
 
 import json
 import logging
-from os import path
+from os import path, makedirs
 from urllib.error import URLError
 from urllib.parse import urlencode, urlsplit, quote
 from urllib.request import Request, urlopen
@@ -151,6 +151,8 @@ def _read_token_cache(creds: ClientCredentials) -> AccessToken:
 # write access token to cache
 def _write_token_cache(creds: ClientCredentials):
     try:
+        cache_dir = path.dirname(_cache_file())
+        makedirs(cache_dir, exist_ok=True)
         cache = _read_cache()
         cache[creds.client_id] = creds.access_token
         with open(_cache_file(), 'w') as f:


### PR DESCRIPTION
It used to be the case that the SDK could write to `~/.rai/tokens.json` no problem because that folder already had to exist for the config setup to work. But now that that folder may be missing, you can end up getting warnings all over the place in code that depends on the SDK (for example, PyRel).

This fix simply checks whether the directory exists before writing the cache and creates it if necessary.