### PR TITLE
bump version

### DIFF
--- a/railib/__init__.py
+++ b/railib/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 7, 1)
+__version_info__ = (0, 7, 2)
 __version__ = ".".join(map(str, __version_info__))

--- a/railib/__init__.py
+++ b/railib/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 7, 0)
+__version_info__ = (0, 7, 1)
 __version__ = ".".join(map(str, __version_info__))


### PR DESCRIPTION
I didn't realize I needed to sync up the version number in this file with the tag number. Thus the release on PyPI failed.