### PR TITLE
Polling fix

### DIFF
--- a/railib/__init__.py
+++ b/railib/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 7, 1)
+__version_info__ = (0, 7, 2)
 __version__ = ".".join(map(str, __version_info__))

--- a/railib/__init__.py
+++ b/railib/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 7, 2)
+__version_info__ = (0, 7, 3)
 __version__ = ".".join(map(str, __version_info__))

--- a/railib/__init__.py
+++ b/railib/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 7, 0)
+__version_info__ = (0, 7, 1)
 __version__ = ".".join(map(str, __version_info__))

--- a/railib/api.py
+++ b/railib/api.py
@@ -324,11 +324,13 @@ def _parse_arrow_results(files: List[TransactionAsyncFile]):
 def poll_with_specified_overhead(
     f,
     overhead_rate: float,
-    start_time: int = time.time(),
+    start_time: float = None,
     timeout: int = None,
     max_tries: int = None,
     max_delay: int = 120,
 ):
+    if start_time is None:
+        start_time = time.time()
     tries = 0
     max_time = time.time() + timeout if timeout else None
 


### PR DESCRIPTION
There was a mistake in a polling function having to do with the way Python evaluates default values for arguments (at definition time).

This PR moves the `time.time()` call to the body of the function.