### PR TITLE
[RAI-25151]: Fix polling duration in ```poll_with_specified_overhead``` function

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -61,5 +61,5 @@ runs:
         CUSTOM_HEADERS: ${{ inputs.custom_headers }}
       run: |
         mkdir -p ~/.rai
-        python -m unittest
+        python -m unittest -v
       shell: bash

--- a/railib/api.py
+++ b/railib/api.py
@@ -333,6 +333,7 @@ def poll_with_specified_overhead(
 ):
     if start_time is None:
         start_time = time.time()
+    
     tries = 0
     max_time = time.time() + timeout if timeout else None
 
@@ -340,18 +341,19 @@ def poll_with_specified_overhead(
         if f():
             break
 
+        current_time = time.time()
+        
         if max_tries is not None and tries >= max_tries:
             raise Exception(f'max tries {max_tries} exhausted')
 
-        if max_time is not None and time.time() >= max_time:
+        if max_time is not None and current_time >= max_time:
             raise Exception(f'timed out after {timeout} seconds')
 
+        duration = (current_time - start_time) * overhead_rate
+        duration = min(duration, max_delay)
+        
+        time.sleep(duration) 
         tries += 1
-        duration = min((time.time() - start_time) * overhead_rate, max_delay)
-        if tries == 1:
-            time.sleep(0.5)
-        else:
-            time.sleep(duration)
 
 
 def is_engine_term_state(state: str) -> bool:

--- a/railib/api.py
+++ b/railib/api.py
@@ -331,6 +331,9 @@ def poll_with_specified_overhead(
     max_tries: int = None,
     max_delay: int = 120,
 ):
+    if overhead_rate < 0:
+        raise ValueError("overhead_rate must be non-negative")
+
     if start_time is None:
         start_time = time.time()
     

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -32,11 +32,15 @@ class TestPolling(unittest.TestCase):
     @patch('time.time')
     def test_initial_delay(self, mock_time, mock_sleep):
         start_time = 100  # Fixed start time
-        mock_time.return_value = start_time + 0.0001  # Fixed increment
+        increment_time = 0.0001
+        mock_time.side_effect = [start_time, start_time + increment_time]  # Simulate time progression
 
-        api.poll_with_specified_overhead(lambda: False, overhead_rate=0.1, max_tries=1)
+        try:
+            api.poll_with_specified_overhead(lambda: False, overhead_rate=0.1, max_tries=2)
+        except Exception as e:
+            pass  # Ignore the exception for this test
 
-        expected_sleep_time = (mock_time.return_value - start_time) * 0.1
+        expected_sleep_time = (start_time + increment_time - start_time) * 0.1
         mock_sleep.assert_called_with(expected_sleep_time)
     
     def test_max_delay_cap(self):

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -10,8 +10,6 @@ from railib.rest import _urlopen_with_retry
 
 
 class TestPolling(unittest.TestCase):
-    @patch('time.sleep', return_value=None)
-    @patch('time.time')
     def test_timeout_exception(self):
         try:
             api.poll_with_specified_overhead(lambda: False, overhead_rate=0.1, timeout=1)
@@ -30,6 +28,8 @@ class TestPolling(unittest.TestCase):
         api.poll_with_specified_overhead(lambda: True, overhead_rate=0.1, max_tries=1)
         api.poll_with_specified_overhead(lambda: True, overhead_rate=0.1, timeout=1, max_tries=1)
 
+    @patch('time.sleep', return_value=None)
+    @patch('time.time')
     def test_initial_delay(self, mock_time, mock_sleep):
         start_time = 100  # Fixed start time
         mock_time.return_value = start_time + 0.0001  # Fixed increment


### PR DESCRIPTION
Fix polling duration calculation in `poll_with_specified_overhead` function. 

It resolves [RAI-25151](https://relationalai.atlassian.net/browse/RAI-25151)

[RAI-25151]: https://relationalai.atlassian.net/browse/RAI-25151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ