### PR TITLE
Bump version to 0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.8
+
+* Relax protobuf upper bound to <6.0.0 for lqp compatibility
+
 ## v0.7.7
 
 * Trigger build workflow / fix issue with pypi

--- a/railib/__init__.py
+++ b/railib/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 7, 7)
+__version_info__ = (0, 7, 8)
 __version__ = ".".join(map(str, __version_info__))


### PR DESCRIPTION
## Summary

- Bumps version to 0.7.8 in `railib/__init__.py`
- Updates `CHANGELOG.md`

Follow-up to #158 (relax protobuf upper bound to <6.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)